### PR TITLE
Add a simple CI for x86_64 and aarch64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: Fortran CI on Fedora 
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Compile Fortran on ${{ matrix.platform }} with ${{ matrix.build_system }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+            build_system: autotools
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+            build_system: autotools
+    runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
+    container:
+      image: fedora:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install gfortran
+        run: |
+           dnf install -y gcc-gfortran gcc-c++ autogen autoconf automake libtool
+           dnf install -y libquadmath-devel || echo "OK" 
+            
+      - name: Compile and run on 
+        run: |
+           if [ "${{ matrix.build_system }}" = "autotools" ]; then
+           autoreconf -i 
+           ./configure  --prefix=$(pwd)/MINSTALL --with-avholo=no --enable-quadninja=yes  --with-quadruple=no --disable-f90module --disable-gosam --disable-avholo_cache --with-looptools=no
+           make -j
+           make install
+           make examples
+           make thread-examples
+           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Fortran CI on Fedora 
+name: CI on Fedora 
 
 on: [push, pull_request]
 
@@ -14,6 +14,12 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-22.04-arm
             build_system: autotools
+          - platform: macos/amd64
+            runner: macos-13
+            build_system: autotools
+          - platform: macos/arm64
+            runner: macos-14
+            build_system: autotools
     runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
     container:
       image: fedora:latest
@@ -21,11 +27,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install gfortran
+      - name: Install dependencies on Fedora
+        if: startsWith(matrix.runner, 'ubuntu')
         run: |
-           dnf install -y gcc-gfortran gcc-c++ autogen autoconf automake libtool
-           dnf install -y libquadmath-devel || echo "OK" 
-            
+          dnf install -y gcc-gfortran gcc-c++ autogen autoconf automake libtool
+          dnf install -y libquadmath-devel || echo "OK"
+
+      - name: Install dependencies on macOS
+        if: startsWith(matrix.runner, 'macos')
+        run: |
+          brew update
+          brew install gcc autoconf automake libtool
+  
       - name: Compile and run
         run: |
            if [ "${{ matrix.build_system }}" = "autotools" ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Install dependencies on macOS
         if: startsWith(matrix.runner, 'macos')
         run: |
-          brew update
           brew install gcc autoconf automake libtool
   
       - name: Compile and run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
            dnf install -y gcc-gfortran gcc-c++ autogen autoconf automake libtool
            dnf install -y libquadmath-devel || echo "OK" 
             
-      - name: Compile and run on 
+      - name: Compile and run
         run: |
            if [ "${{ matrix.build_system }}" = "autotools" ]; then
            autoreconf -i 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,4 @@ jobs:
            ./configure  --prefix=$(pwd)/MINSTALL --with-avholo=no --enable-quadninja=no  --with-quadruple=no --disable-f90module --disable-gosam --disable-avholo_cache --with-looptools=no
            make -j
            make install
-           make examples
-           make thread-examples
            fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
            if [ "${{ matrix.build_system }}" = "autotools" ]; then
            autoreconf -i 
-           ./configure  --prefix=$(pwd)/MINSTALL --with-avholo=no --enable-quadninja=yes  --with-quadruple=no --disable-f90module --disable-gosam --disable-avholo_cache --with-looptools=no
+           ./configure  --prefix=$(pwd)/MINSTALL --with-avholo=no --enable-quadninja=no  --with-quadruple=no --disable-f90module --disable-gosam --disable-avholo_cache --with-looptools=no
            make -j
            make install
            make examples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,7 @@ jobs:
             runner: macos-14
             build_system: autotools
     runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
-    container:
-      image: fedora:latest
+    container: ${{ startsWith(matrix.runner, 'ubuntu') && 'fedora:latest' || null }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Add a simple CI for:
  - Fedora Linux  x86_64 
  - Fedora Linux aarch64
  - Mac OS 13 x86_64 
  - Mac OS 14 aarch64
So far quadninja is disabled.
